### PR TITLE
Add validation helpers and missing tests for Require* methods

### DIFF
--- a/pkg/internal/errors/errors.go
+++ b/pkg/internal/errors/errors.go
@@ -71,14 +71,20 @@ var (
 	// ErrHistoryNotInitialized indicates that the history has not been initialized prior to use.
 	ErrHistoryNotInitialized = errors.New("history not initialized")
 
-	// ErrHistoryIsEmpty indicates that a history operation was attempted on an empty history.
-	ErrHistoryIsEmpty = errors.New("history is empty")
-
 	// ErrInvalidNgramMap indicates that the provided ngram map is invalid.
 	ErrInvalidNgramMap = errors.New("invalid ngram map")
 
 	// ErrPatternNotFound indicates that the specified pattern could not be found.
 	ErrPatternNotFound = errors.New("pattern not found")
+
+	// ErrDoesNotContainSubstring indicates that a string does not contain the expected substring.
+	ErrDoesNotContainSubstring = errors.New("does not contain substring")
+
+	// ErrMissingPrefix indicates that a required prefix is missing from a given string.
+	ErrMissingPrefix = errors.New("missing prefix")
+
+	// ErrMissingSuffix indicates that the required suffix is missing from a string.
+	ErrMissingSuffix = errors.New("missing suffix")
 )
 
 // CompareErrors compares two error values for equality by checking their string representations.

--- a/pkg/strutil/builder_test.go
+++ b/pkg/strutil/builder_test.go
@@ -550,6 +550,78 @@ func TestBuilderError(t *testing.T) {
 				t.Errorf("RemoveANSIEscapeCodes failed, expected %t, got %t", tt.expected,
 					tt.input.RemoveANSIEscapeCodes().String() == "")
 			}
+			if tt.input.RequireContains(compWord).String() == "" != tt.expected {
+				t.Errorf("RequireContains failed, expected %t, got %t", tt.expected,
+					tt.input.RequireContains(compWord).String() == "")
+			}
+			if tt.input.RequireContainsIgnoreCase(compWord).String() == "" != tt.expected {
+				t.Errorf("RequireContainsIgnoreCase failed, expected %t, got %t", tt.expected,
+					tt.input.RequireContainsIgnoreCase(compWord).String() == "")
+			}
+			if tt.input.RequireContainsAny([]string{compWord}).String() == "" != tt.expected {
+				t.Errorf("RequireContainsAny failed, expected %t, got %t", tt.expected,
+					tt.input.RequireContainsAny([]string{compWord}).String() == "")
+			}
+			if tt.input.RequireContainsAnyIgnoreCase([]string{compWord}).String() == "" != tt.expected {
+				t.Errorf("RequireContainsAnyIgnoreCase failed, expected %t, got %t", tt.expected,
+					tt.input.RequireContainsAnyIgnoreCase([]string{compWord}).String() == "")
+			}
+			if tt.input.RequireContainsAll([]string{compWord}).String() == "" != tt.expected {
+				t.Errorf("RequireContainsAll failed, expected %t, got %t", tt.expected,
+					tt.input.RequireContainsAll([]string{compWord}).String() == "")
+			}
+			if tt.input.RequireContainsAllIgnoreCase([]string{compWord}).String() == "" != tt.expected {
+				t.Errorf("RequireContainsAllIgnoreCase failed, expected %t, got %t", tt.expected,
+					tt.input.RequireContainsAllIgnoreCase([]string{compWord}).String() == "")
+			}
+			if tt.input.RequireHasPrefix(compWord).String() == "" != tt.expected {
+				t.Errorf("RequireHasPrefix failed, expected %t, got %t", tt.expected,
+					tt.input.RequireHasPrefix(compWord).String() == "")
+			}
+			if tt.input.RequireHasSuffix(compWord).String() == "" != tt.expected {
+				t.Errorf("RequireHasSuffix failed, expected %t, got %t", tt.expected,
+					tt.input.RequireHasSuffix(compWord).String() == "")
+			}
+			if tt.input.RequireEmail().String() == "" != tt.expected {
+				t.Errorf("RequireEmail failed, expected %t, got %t", tt.expected,
+					tt.input.RequireEmail().String() == "")
+			}
+			if tt.input.RequireDomain().String() == "" != tt.expected {
+				t.Errorf("RequireDomain failed, expected %t, got %t", tt.expected,
+					tt.input.RequireDomain().String() == "")
+			}
+			if tt.input.RequireURL().String() == "" != tt.expected {
+				t.Errorf("RequireURL failed, expected %t, got %t", tt.expected,
+					tt.input.RequireURL().String() == "")
+			}
+			if tt.input.RequireUUID().String() == "" != tt.expected {
+				t.Errorf("RequireUUID failed, expected %t, got %t", tt.expected,
+					tt.input.RequireUUID().String() == "")
+			}
+			if tt.input.RequireLength(0, 100).String() == "" != tt.expected {
+				t.Errorf("RequireLength failed, expected %t, got %t", tt.expected,
+					tt.input.RequireLength(0, 100).String() == "")
+			}
+			if tt.input.RequireNotEmpty().String() == "" != tt.expected {
+				t.Errorf("RequireNotEmpty failed, expected %t, got %t", tt.expected,
+					tt.input.RequireNotEmpty().String() == "")
+			}
+			if tt.input.RequireNotEmptyNormalized().String() == "" != tt.expected {
+				t.Errorf("RequireNotEmptyNormalized failed, expected %t, got %t", tt.expected,
+					tt.input.RequireNotEmptyNormalized().String() == "")
+			}
+			if tt.input.RequireAlpha().String() == "" != tt.expected {
+				t.Errorf("RequireAlpha failed, expected %t, got %t", tt.expected,
+					tt.input.RequireAlpha().String() == "")
+			}
+			if tt.input.RequireAlphaNumeric().String() == "" != tt.expected {
+				t.Errorf("RequireAlphaNumeric failed, expected %t, got %t", tt.expected,
+					tt.input.RequireAlphaNumeric().String() == "")
+			}
+			if tt.input.RequireNormalizedUnicode(NFC).String() == "" != tt.expected {
+				t.Errorf("RequireNormalizedUnicode failed, expected %t, got %t", tt.expected,
+					tt.input.RequireNormalizedUnicode(NFC).String() == "")
+			}
 		})
 	}
 }

--- a/pkg/strutil/builder_test.go
+++ b/pkg/strutil/builder_test.go
@@ -436,30 +436,6 @@ func TestBuilderError(t *testing.T) {
 				t.Errorf("SanitizeHTML failed, expected %t, got %t", tt.expected,
 					tt.input.SanitizeHTML().String() == "")
 			}
-			//if tt.input.RemoveNonPrintable().String() == "" != tt.expected {
-			//	t.Errorf("RemoveNonPrintable failed, expected %t, got %t", tt.expected,
-			//		tt.input.RemoveNonPrintable().String() == "")
-			//}
-			//if tt.input.RemoveANSIEscapeCodes().String() == "" != tt.expected {
-			//	t.Errorf("RemoveANSIEscapeCodes failed, expected %t, got %t", tt.expected,
-			//		tt.input.RemoveANSIEscapeCodes().String() == "")
-			//}
-			//if tt.input.SanitizeFilename().String() == "" != tt.expected {
-			//	t.Errorf("SanitizeFilename failed, expected %t, got %t", tt.expected,
-			//		tt.input.SanitizeFilename().String() == "")
-			//}
-			//if tt.input.SanitizePath().String() == "" != tt.expected {
-			//	t.Errorf("SanitizePath failed, expected %t, got %t", tt.expected,
-			//		tt.input.SanitizePath().String() == "")
-			//}
-			//if tt.input.SanitizeEmail().String() == "" != tt.expected {
-			//	t.Errorf("SanitizeEmail failed, expected %t, got %t", tt.expected,
-			//		tt.input.SanitizeEmail().String() == "")
-			//}
-			//if tt.input.SanitizeUsername().String() == "" != tt.expected {
-			//	t.Errorf("SanitizeUsername failed, expected %t, got %t", tt.expected,
-			//		tt.input.SanitizeUsername().String() == "")
-			//}
 			if tt.input.LevenshteinDistance(compWord).String() == "" != tt.expected {
 				t.Errorf("LevenshteinDistance failed, expected %t, got %t", tt.expected,
 					tt.input.LevenshteinDistance(compWord).String() == "")
@@ -550,78 +526,431 @@ func TestBuilderError(t *testing.T) {
 				t.Errorf("RemoveANSIEscapeCodes failed, expected %t, got %t", tt.expected,
 					tt.input.RemoveANSIEscapeCodes().String() == "")
 			}
-			if tt.input.RequireContains(compWord).String() == "" != tt.expected {
-				t.Errorf("RequireContains failed, expected %t, got %t", tt.expected,
-					tt.input.RequireContains(compWord).String() == "")
-			}
-			if tt.input.RequireContainsIgnoreCase(compWord).String() == "" != tt.expected {
-				t.Errorf("RequireContainsIgnoreCase failed, expected %t, got %t", tt.expected,
-					tt.input.RequireContainsIgnoreCase(compWord).String() == "")
-			}
-			if tt.input.RequireContainsAny([]string{compWord}).String() == "" != tt.expected {
-				t.Errorf("RequireContainsAny failed, expected %t, got %t", tt.expected,
-					tt.input.RequireContainsAny([]string{compWord}).String() == "")
-			}
-			if tt.input.RequireContainsAnyIgnoreCase([]string{compWord}).String() == "" != tt.expected {
-				t.Errorf("RequireContainsAnyIgnoreCase failed, expected %t, got %t", tt.expected,
-					tt.input.RequireContainsAnyIgnoreCase([]string{compWord}).String() == "")
-			}
-			if tt.input.RequireContainsAll([]string{compWord}).String() == "" != tt.expected {
-				t.Errorf("RequireContainsAll failed, expected %t, got %t", tt.expected,
-					tt.input.RequireContainsAll([]string{compWord}).String() == "")
-			}
-			if tt.input.RequireContainsAllIgnoreCase([]string{compWord}).String() == "" != tt.expected {
-				t.Errorf("RequireContainsAllIgnoreCase failed, expected %t, got %t", tt.expected,
-					tt.input.RequireContainsAllIgnoreCase([]string{compWord}).String() == "")
-			}
-			if tt.input.RequireHasPrefix(compWord).String() == "" != tt.expected {
-				t.Errorf("RequireHasPrefix failed, expected %t, got %t", tt.expected,
-					tt.input.RequireHasPrefix(compWord).String() == "")
-			}
-			if tt.input.RequireHasSuffix(compWord).String() == "" != tt.expected {
-				t.Errorf("RequireHasSuffix failed, expected %t, got %t", tt.expected,
-					tt.input.RequireHasSuffix(compWord).String() == "")
-			}
-			if tt.input.RequireEmail().String() == "" != tt.expected {
-				t.Errorf("RequireEmail failed, expected %t, got %t", tt.expected,
-					tt.input.RequireEmail().String() == "")
-			}
-			if tt.input.RequireDomain().String() == "" != tt.expected {
-				t.Errorf("RequireDomain failed, expected %t, got %t", tt.expected,
-					tt.input.RequireDomain().String() == "")
-			}
-			if tt.input.RequireURL().String() == "" != tt.expected {
-				t.Errorf("RequireURL failed, expected %t, got %t", tt.expected,
-					tt.input.RequireURL().String() == "")
-			}
-			if tt.input.RequireUUID().String() == "" != tt.expected {
-				t.Errorf("RequireUUID failed, expected %t, got %t", tt.expected,
-					tt.input.RequireUUID().String() == "")
-			}
-			if tt.input.RequireLength(0, 100).String() == "" != tt.expected {
-				t.Errorf("RequireLength failed, expected %t, got %t", tt.expected,
-					tt.input.RequireLength(0, 100).String() == "")
-			}
-			if tt.input.RequireNotEmpty().String() == "" != tt.expected {
-				t.Errorf("RequireNotEmpty failed, expected %t, got %t", tt.expected,
-					tt.input.RequireNotEmpty().String() == "")
-			}
-			if tt.input.RequireNotEmptyNormalized().String() == "" != tt.expected {
-				t.Errorf("RequireNotEmptyNormalized failed, expected %t, got %t", tt.expected,
-					tt.input.RequireNotEmptyNormalized().String() == "")
-			}
-			if tt.input.RequireAlpha().String() == "" != tt.expected {
-				t.Errorf("RequireAlpha failed, expected %t, got %t", tt.expected,
-					tt.input.RequireAlpha().String() == "")
-			}
-			if tt.input.RequireAlphaNumeric().String() == "" != tt.expected {
-				t.Errorf("RequireAlphaNumeric failed, expected %t, got %t", tt.expected,
-					tt.input.RequireAlphaNumeric().String() == "")
-			}
-			if tt.input.RequireNormalizedUnicode(NFC).String() == "" != tt.expected {
-				t.Errorf("RequireNormalizedUnicode failed, expected %t, got %t", tt.expected,
-					tt.input.RequireNormalizedUnicode(NFC).String() == "")
-			}
 		})
+	}
+}
+
+func TestBuilderRequiresEmail(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("guy@email.com"), true},
+		{New("guy"), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireEmail().String() == "" {
+			t.Errorf("RequireEmail failed, expected %t, got %t", tt.passed,
+				tt.input.RequireEmail().String() == "")
+		}
+		if !tt.passed && tt.input.RequireEmail().String() != "" {
+			t.Errorf("RequireEmail failed, expected %t, got %t", tt.passed,
+				tt.input.RequireEmail().String() == "")
+		}
+	}
+}
+
+func TestBuilderRequiresDomain(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("sub.my.home"), true},
+		{New("9081---12"), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireDomain().String() == "" {
+			t.Errorf("RequireDomain failed, expected %t, got %t", tt.passed,
+				tt.input.RequireDomain().String() == "")
+		}
+		if !tt.passed && tt.input.RequireDomain().String() != "" {
+			t.Errorf("RequireDomain failed, expected %t, got %t", tt.passed,
+				tt.input.RequireDomain().String() == "")
+		}
+	}
+}
+
+func TestBuilderRequiresURL(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("https://www.google.com"), true},
+		{New("hello world"), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireURL().String() == "" {
+			t.Errorf("RequireURL failed, expected %t, got %t", tt.passed,
+				tt.input.RequireURL().String() == "")
+		}
+		if !tt.passed && tt.input.RequireURL().String() != "" {
+			t.Errorf("RequireURL failed, expected %t, got %t", tt.passed,
+				tt.input.RequireURL().String() == "")
+		}
+	}
+}
+
+func TestBuilderRequiresUUID(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("0198a5ea-423d-7ad2-916d-d91b01dad7c7"), true},
+		{New("hello world"), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireUUID().String() == "" {
+			t.Errorf("RequireUUID failed, expected %t, got %t", tt.passed,
+				tt.input.RequireUUID().String() == "")
+		}
+		if !tt.passed && tt.input.RequireUUID().String() != "" {
+			t.Errorf("RequireUUID failed, expected %t, got %t", tt.passed,
+				tt.input.RequireUUID().String() == "")
+		}
+	}
+}
+
+func TestBuilderRequiresLength(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		min    int
+		max    int
+		passed bool
+	}{
+		{New("hello world"), 1, 100, true},
+		{New("hello world"), 25, 255, false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), 1, 100, false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireLength(tt.min, tt.max).String() == "" {
+			t.Errorf("RequireLength failed, expected %t, got %t", tt.passed,
+				tt.input.RequireLength(tt.min, tt.max).String() == "")
+		}
+		if !tt.passed && tt.input.RequireLength(tt.min, tt.max).String() != "" {
+			t.Errorf("RequireLength failed, expected %t, got %t", tt.passed,
+				tt.input.RequireLength(tt.min, tt.max).String() == "")
+		}
+	}
+}
+
+func TestRequireNotEmpty(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("hello world"), true},
+		{New(""), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireNotEmpty().String() == "" {
+			t.Errorf("RequireNotEmpty failed, expected %t, got %t", tt.passed,
+				tt.input.RequireNotEmpty().String() == "")
+		}
+		if !tt.passed && tt.input.RequireNotEmpty().String() != "" {
+			t.Errorf("RequireNotEmpty failed, expected %t, got %t", tt.passed,
+				tt.input.RequireNotEmpty().String() == "")
+		}
+	}
+}
+
+func TestRequireNotEmptyNormalized(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("hello world"), true},
+		{New("   "), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireNotEmptyNormalized().String() == "" {
+			t.Errorf("RequireNotEmptyNormalized failed, expected %t, got %t", tt.passed,
+				tt.input.RequireNotEmptyNormalized().String() == "")
+		}
+		if !tt.passed && tt.input.RequireNotEmptyNormalized().String() != "" {
+			t.Errorf("RequireNotEmptyNormalized failed, expected %t, got %t", tt.passed,
+				tt.input.RequireNotEmptyNormalized().String() == "")
+		}
+	}
+}
+
+func TestRequireAlpha(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("helloworld"), true},
+		{New("hello world!"), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireAlpha().String() == "" {
+			t.Errorf("RequireAlpha failed, expected %t, got %t", tt.passed,
+				tt.input.RequireAlpha().String() == "")
+		}
+		if !tt.passed && tt.input.RequireAlpha().String() != "" {
+			t.Errorf("RequireAlpha failed, expected %t, got %t", tt.passed,
+				tt.input.RequireAlpha().String() == "")
+		}
+	}
+
+}
+
+func TestRequireAlphaNumeric(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		passed bool
+	}{
+		{New("helloworld123"), true},
+		{New("hello world!"), false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireAlphaNumeric().String() == "" {
+			t.Errorf("RequireAlphaNumeric failed, expected %t, got %t", tt.passed,
+				tt.input.RequireAlphaNumeric().String() == "")
+		}
+		if !tt.passed && tt.input.RequireAlphaNumeric().String() != "" {
+			t.Errorf("RequireAlphaNumeric failed, expected %t, got %t", tt.passed,
+				tt.input.RequireAlphaNumeric().String() == "")
+		}
+	}
+}
+
+func TestRequireNormalizedUnicode(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		form   NormalizationFormat
+		passed bool
+	}{
+		{New("hello world"), NFC, true},
+		{New("w̤𝓲𝔱𝙝 𝔣🇦m̤𝗂𝚕ⓨ ⒜ｎ𝐝 f́r̤ï𝘦⒩𝚍s̤❗❕"), NFD, false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), NFC, false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireNormalizedUnicode(tt.form).String() == "" {
+			t.Errorf("RequireNormalizedUnicode failed, expected %t, got %t", tt.passed,
+				tt.input.RequireNormalizedUnicode(tt.form).String() == "")
+		}
+		res2 := tt.input.RequireNormalizedUnicode(tt.form).String()
+		if !tt.passed && res2 != "" {
+			t.Errorf("RequireNormalizedUnicode failed, expected %t, got %t", tt.passed,
+				tt.input.RequireNormalizedUnicode(tt.form).String() == "")
+		}
+	}
+}
+
+func TestRequireContains(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   string
+		passed bool
+	}{
+		{New("hello world"), "world", true},
+		{New("hello world"), "hi", false},
+		{New("hello world"), "HELLO", false},
+		{New("hello world"), "", false},
+		{New(""), "hello", false},
+		{New(""), "", false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), "", false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireContains(tt.comp).String() == "" {
+			t.Errorf("RequireContains failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContains(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireContains(tt.comp).String() != "" {
+			t.Errorf("RequireContains failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContains(tt.comp).String() == "")
+		}
+	}
+}
+
+func TestRequireContainsIgnoreCase(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   string
+		passed bool
+	}{
+		{New("hello world"), "world", true},
+		{New("hello world"), "hi", false},
+		{New("hello world"), "HELLO", true},
+		{New("hello world"), "", false},
+		{New(""), "hello", false},
+		{New(""), "", false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), "", false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireContainsIgnoreCase(tt.comp).String() == "" {
+			t.Errorf("RequireContainsIgnoreCase failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContains(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireContainsIgnoreCase(tt.comp).String() != "" {
+			t.Errorf("RequireContainsIgnoreCase failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsIgnoreCase(tt.comp).String() == "")
+		}
+	}
+}
+
+func TestRequireContainsAny(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   []string
+		passed bool
+	}{
+		{New("hello world"), []string{"world", "hi"}, true},
+		{New("HELLO WORLD"), []string{"hi", "HELLO"}, true},
+		{New("hello world"), []string{"HELLO", "hi"}, false},
+		{New("hello world"), []string{"", "hi"}, false},
+		{New("hello world"), []string{}, false},
+		{New(""), []string{"hello", "hi"}, false},
+		{New(""), []string{}, false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), []string{}, false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireContainsAny(tt.comp).String() == "" {
+			t.Errorf("RequireContainsAny failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAny(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireContainsAny(tt.comp).String() != "" {
+			t.Errorf("RequireContainsAny failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAny(tt.comp).String() != "")
+		}
+	}
+}
+
+func TestRequireContainsAnyIgnoreCase(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   []string
+		passed bool
+	}{
+		{New("hello world"), []string{"world", "hi"}, true},
+		{New("HELLO WORLD"), []string{"hi", "HELLO"}, true},
+		{New("hello world"), []string{"HELLO", "hi"}, true},
+		{New("hello world"), []string{"", "hi"}, false},
+		{New("hello world"), []string{}, false},
+		{New(""), []string{"hello", "hi"}, false},
+		{New(""), []string{}, false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), []string{}, false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireContainsAnyIgnoreCase(tt.comp).String() == "" {
+			t.Errorf("RequireContainsAnyIgnoreCase failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAnyIgnoreCase(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireContainsAnyIgnoreCase(tt.comp).String() != "" {
+			t.Errorf("RequireContainsAnyIgnoreCase failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAnyIgnoreCase(tt.comp).String() != "")
+		}
+	}
+}
+
+func TestRequireContainsAll(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   []string
+		passed bool
+	}{
+		{New("hello world"), []string{"world", "hello"}, true},
+		{New("HELLO WORLD"), []string{"hi", "HELLO"}, false},
+		{New("hello world"), []string{"HELLO", "world"}, false},
+		{New("hello world"), []string{"", "hi"}, false},
+		{New("hello world"), []string{}, false},
+		{New(""), []string{"hello", "hi"}, false},
+		{New(""), []string{}, false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), []string{}, false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireContainsAll(tt.comp).String() == "" {
+			t.Errorf("RequireContainsAll failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAll(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireContainsAll(tt.comp).String() != "" {
+			t.Errorf("RequireContainsAll failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAll(tt.comp).String() != "")
+		}
+	}
+}
+
+func TestStringBuilderRequireContainsAllIgnoreCase(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   []string
+		passed bool
+	}{
+		{New("hello world"), []string{"world", "hello"}, true},
+		{New("HELLO WORLD"), []string{"hi", "HELLO"}, false},
+		{New("hello world"), []string{"HELLO", "world"}, true},
+		{New("hello world"), []string{"", "hi"}, false},
+		{New("hello world"), []string{}, false},
+		{New(""), []string{"hello", "hi"}, false},
+		{New(""), []string{}, false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), []string{}, false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireContainsAllIgnoreCase(tt.comp).String() == "" {
+			t.Errorf("RequireContainsAllI failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAll(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireContainsAllIgnoreCase(tt.comp).String() != "" {
+			t.Errorf("RequireContainsAllIgnoreCase failed, expected %t, got %t", tt.passed,
+				tt.input.RequireContainsAllIgnoreCase(tt.comp).String() != "")
+		}
+	}
+}
+
+func TestRequireHasPrefix(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   string
+		passed bool
+	}{
+		{New("pre-release"), "pre", true},
+		{New("APP_ENV_VAR"), "APP", true},
+		{New("hello world"), "", false},
+		{New(""), "hello", false},
+		{New(""), "", false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), "", false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireHasPrefix(tt.comp).String() == "" {
+			t.Errorf("RequireHasPrefix failed, expected %t, got %t", tt.passed,
+				tt.input.RequireHasPrefix(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireHasPrefix(tt.comp).String() != "" {
+			t.Errorf("RequireHasPrefix failed, expected %t, got %t", tt.passed,
+				tt.input.RequireHasPrefix(tt.comp).String() == "")
+		}
+	}
+}
+
+func TestRequireHasSuffix(t *testing.T) {
+	tests := []struct {
+		input  *StringBuilder
+		comp   string
+		passed bool
+	}{
+		{New("Hello World!"), "!", true},
+		{New("Hello World"), "!", false},
+		{New("hello world"), "", false},
+		{New(""), "hello", false},
+		{New(""), "", false},
+		{New("guy@email").setError(errors.ErrUnknownError, true), "", false},
+	}
+	for _, tt := range tests {
+		if tt.passed && tt.input.RequireHasSuffix(tt.comp).String() == "" {
+			t.Errorf("RequireHasSuffix failed, expected %t, got %t", tt.passed,
+				tt.input.RequireHasSuffix(tt.comp).String() == "")
+		}
+		if !tt.passed && tt.input.RequireHasSuffix(tt.comp).String() != "" {
+			t.Errorf("RequireHasSuffix failed, expected %t, got %t", tt.passed,
+				tt.input.RequireHasSuffix(tt.comp).String() == "")
+		}
 	}
 }

--- a/pkg/strutil/validation.go
+++ b/pkg/strutil/validation.go
@@ -1,6 +1,7 @@
 package strutil
 
-// IsEmail checks if the input string is in a valid email address format and returns true if valid, false otherwise.
+// IsEmail checks if the input string is in a valid email address format and
+// returns true if valid, false otherwise.
 func IsEmail(s string) bool {
 	return isValidEmail(s)
 }
@@ -21,7 +22,8 @@ func IsUUID(s string) bool {
 	return isValidUUID(s)
 }
 
-// IsValidLength checks if the length of the given string s is within the inclusive range defined by min and max values.
+// IsValidLength checks if the length of the given string s is within the inclusive range
+// defined by min and max values.
 func IsValidLength(s string, min, max int) bool {
 	return isLengthInRange(s, min, max)
 }
@@ -48,21 +50,51 @@ func IsAlphaString(s string) bool {
 	return isAlphaString(s)
 }
 
-// IsNormalizedUnicode checks if the given string is normalized according to the specified Unicode normalization format.
+// IsNormalizedUnicode checks if the given string is normalized according to the specified
+// Unicode normalization format.
 func IsNormalizedUnicode(s string, format NormalizationFormat) bool {
 	return isNormalizedUnicode(s, format)
 }
 
-// input validation
+// Contains checks if the substring `substr` is present within the string `s` and
+// returns true if found, otherwise false.
+func Contains(s string, substr string) bool {
+	return contains(s, substr)
+}
 
-//func FormatCardNumber(s string) string {
-//	panic("Implement me!")
-//}
+// ContainsIgnoreCase checks if substr is present in s, ignoring case sensitivity. Returns true if found.
+func ContainsIgnoreCase(s string, substr string) bool {
+	return containsIgnoreCase(s, substr)
+}
 
-//func FormatSSN(s string) string {
-//	panic("Implement me!")
-//}
+// ContainsAny checks if any substring in the slice `substrs` exists in the string `s` and returns true if found.
+func ContainsAny(s string, substrs []string) bool {
+	return containsAny(s, substrs)
+}
 
-//func FormatPhone(s string, format PhoneFormat) string {
-//	panic("Implement me!")
-//}
+// ContainsAnyIgnoreCase checks if the input string contains any of the provided substrings,
+// ignoring case sensitivity.
+func ContainsAnyIgnoreCase(s string, substrs []string) bool {
+	return containsAnyIgnoreCase(s, substrs)
+}
+
+// ContainsAll checks if all strings in the slice substrs are present within the string s, returning true if found.
+func ContainsAll(s string, substrs []string) bool {
+	return containsAll(s, substrs)
+}
+
+// ContainsAllIgnoreCase checks if all substrings in the provided slice are found in the string,
+// ignoring case sensitivity.
+func ContainsAllIgnoreCase(s string, substrs []string) bool {
+	return containsAllIgnoreCase(s, substrs)
+}
+
+// HasPrefix reports whether the string s begins with the specified prefix. Returns true if it does, otherwise false.
+func HasPrefix(s string, prefix string) bool {
+	return hasPrefix(s, prefix)
+}
+
+// HasSuffix reports whether the string `s` ends with the specified `suffix`.
+func HasSuffix(s string, suffix string) bool {
+	return hasSuffix(s, suffix)
+}

--- a/pkg/strutil/validation_builder.go
+++ b/pkg/strutil/validation_builder.go
@@ -126,88 +126,97 @@ func (sb *StringBuilder) RequireNormalizedUnicode(format NormalizationFormat) *S
 	return sb
 }
 
-// RequireContains ensures the StringBuilder's value contains the specified substring or sets an error if not.
+// RequireContains ensures that the StringBuilder's value contains the specified substring.
+// If the substring is not found, it sets an error and halts further processing.
 func (sb *StringBuilder) RequireContains(substr string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !contains(sb.value, substr) {
-		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+		return sb.setError(errors.ErrDoesNotContainSubstring, true)
 	}
 	return sb
 }
 
-// RequireContainsIgnoreCase ensures the StringBuilder's value contains the specified substring,
-// ignoring case sensitivity.
-// If the substring is not found, it sets an error and stops further processing.
-// Returns the updated StringBuilder instance.
+// RequireContainsIgnoreCase verifies that the StringBuilder's value contains the given substring, ignoring case.
+// Returns the StringBuilder itself, or sets an error if the substring is not found.
 func (sb *StringBuilder) RequireContainsIgnoreCase(substr string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !containsIgnoreCase(sb.value, substr) {
-		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+		return sb.setError(errors.ErrDoesNotContainSubstring, true)
 	}
 	return sb
 }
 
-// RequireContainsAny ensures the string contains at least one of the specified substrings or sets an error if not.
+// RequireContainsAny ensures the string contains at least one of the specified substrings, else sets an error.
 func (sb *StringBuilder) RequireContainsAny(substrs []string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !containsAny(sb.value, substrs) {
-		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+		return sb.setError(errors.ErrDoesNotContainSubstring, true)
 	}
 	return sb
 }
 
+// RequireContainsAnyIgnoreCase ensures the string contains at least one of the specified substrings, disregarding case.
+// If none of the substrings are found, it sets an error and halts further processing.
+// Returns the updated StringBuilder instance.
 func (sb *StringBuilder) RequireContainsAnyIgnoreCase(substrs []string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !containsAnyIgnoreCase(sb.value, substrs) {
-		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+		return sb.setError(errors.ErrDoesNotContainSubstring, true)
 	}
 	return sb
 }
 
+// RequireContainsAll ensures the StringBuilder's value contains all provided substrings; sets an error if not.
 func (sb *StringBuilder) RequireContainsAll(substrs []string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !containsAll(sb.value, substrs) {
-		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+		return sb.setError(errors.ErrDoesNotContainSubstring, true)
 	}
 	return sb
 }
 
+// RequireContainsAllIgnoreCase checks if all substrings in the slice exist in the current value,
+// ignoring case sensitivity.
+// Returns the StringBuilder instance with an error set if any substring is missing.
 func (sb *StringBuilder) RequireContainsAllIgnoreCase(substrs []string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !containsAllIgnoreCase(sb.value, substrs) {
-		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+		return sb.setError(errors.ErrDoesNotContainSubstring, true)
 	}
 	return sb
 }
 
+// RequireHasPrefix ensures the builder's string value has the specified prefix or sets an error
+// if the prefix is missing.
 func (sb *StringBuilder) RequireHasPrefix(prefix string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !hasPrefix(sb.value, prefix) {
-		return sb.setError(errors.ErrMissingPrefix, false)
+		return sb.setError(errors.ErrMissingPrefix, true)
 	}
 	return sb
 }
 
+// RequireHasSuffix ensures the StringBuilder's value ends with the specified suffix, setting an error if not.
 func (sb *StringBuilder) RequireHasSuffix(suffix string) *StringBuilder {
 	if !sb.shouldContinueProcessing() {
 		return sb
 	}
 	if !hasSuffix(sb.value, suffix) {
-		return sb.setError(errors.ErrMissingSuffix, false)
+		return sb.setError(errors.ErrMissingSuffix, true)
 	}
 	return sb
 }

--- a/pkg/strutil/validation_builder.go
+++ b/pkg/strutil/validation_builder.go
@@ -125,3 +125,89 @@ func (sb *StringBuilder) RequireNormalizedUnicode(format NormalizationFormat) *S
 	}
 	return sb
 }
+
+// RequireContains ensures the StringBuilder's value contains the specified substring or sets an error if not.
+func (sb *StringBuilder) RequireContains(substr string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !contains(sb.value, substr) {
+		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+	}
+	return sb
+}
+
+// RequireContainsIgnoreCase ensures the StringBuilder's value contains the specified substring,
+// ignoring case sensitivity.
+// If the substring is not found, it sets an error and stops further processing.
+// Returns the updated StringBuilder instance.
+func (sb *StringBuilder) RequireContainsIgnoreCase(substr string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !containsIgnoreCase(sb.value, substr) {
+		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+	}
+	return sb
+}
+
+// RequireContainsAny ensures the string contains at least one of the specified substrings or sets an error if not.
+func (sb *StringBuilder) RequireContainsAny(substrs []string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !containsAny(sb.value, substrs) {
+		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+	}
+	return sb
+}
+
+func (sb *StringBuilder) RequireContainsAnyIgnoreCase(substrs []string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !containsAnyIgnoreCase(sb.value, substrs) {
+		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+	}
+	return sb
+}
+
+func (sb *StringBuilder) RequireContainsAll(substrs []string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !containsAll(sb.value, substrs) {
+		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+	}
+	return sb
+}
+
+func (sb *StringBuilder) RequireContainsAllIgnoreCase(substrs []string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !containsAllIgnoreCase(sb.value, substrs) {
+		return sb.setError(errors.ErrDoesNotContainSubstring, false)
+	}
+	return sb
+}
+
+func (sb *StringBuilder) RequireHasPrefix(prefix string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !hasPrefix(sb.value, prefix) {
+		return sb.setError(errors.ErrMissingPrefix, false)
+	}
+	return sb
+}
+
+func (sb *StringBuilder) RequireHasSuffix(suffix string) *StringBuilder {
+	if !sb.shouldContinueProcessing() {
+		return sb
+	}
+	if !hasSuffix(sb.value, suffix) {
+		return sb.setError(errors.ErrMissingSuffix, false)
+	}
+	return sb
+}

--- a/pkg/strutil/validation_helpers.go
+++ b/pkg/strutil/validation_helpers.go
@@ -90,3 +90,90 @@ func isAlphaString(s string) bool {
 func isNormalizedUnicode(s string, format NormalizationFormat) bool {
 	return norm.Form(format).IsNormalString(s)
 }
+
+// contains determines if the substring `substr` exists within the string `s` and returns true if found,
+// otherwise false.
+func contains(s string, substr string) bool {
+	if isEmpty(s) || isEmpty(substr) {
+		return false
+	}
+	return strings.Contains(s, substr)
+}
+
+// containsIgnoreCase checks if substr is present in s, ignoring case sensitivity. Returns true if found,
+// false otherwise.
+func containsIgnoreCase(s string, substr string) bool {
+	if isEmpty(s) || isEmpty(substr) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+// containsAny checks if any string in the slice substrs is present in the string s and returns true if found.
+func containsAny(s string, substrs []string) bool {
+	if isEmpty(s) || len(substrs) == 0 {
+		return false
+	}
+	for _, substr := range substrs {
+		if contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAnyIgnoreCase checks if the input string contains any of the given substrings, ignoring case sensitivity.
+func containsAnyIgnoreCase(s string, substrs []string) bool {
+	if isEmpty(s) || len(substrs) == 0 {
+		return false
+	}
+	for _, substr := range substrs {
+		if containsIgnoreCase(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAll returns true if all strings in substrs are present in s; returns false if s is empty or substrs is empty.
+func containsAll(s string, substrs []string) bool {
+	if isEmpty(s) || len(substrs) == 0 {
+		return false
+	}
+	for _, substr := range substrs {
+		if !contains(s, substr) {
+			return false
+		}
+	}
+	return true
+}
+
+// containsAllIgnoreCase checks if all substrings in the slice are present in the given string,
+// ignoring case sensitivity.
+func containsAllIgnoreCase(s string, substrs []string) bool {
+	if isEmpty(s) || len(substrs) == 0 {
+		return false
+	}
+	for _, substr := range substrs {
+		if !containsIgnoreCase(s, substr) {
+			return false
+		}
+	}
+	return true
+}
+
+// hasPrefix checks if the string 's' starts with the specified 'prefix'. Returns true if it does, otherwise false.
+func hasPrefix(s string, prefix string) bool {
+	if isEmpty(s) || isEmpty(prefix) {
+		return false
+	}
+	return strings.HasPrefix(s, prefix)
+}
+
+// hasSuffix checks if the string `s` ends with the given `suffix` and returns true if it does, otherwise false.
+func hasSuffix(s string, suffix string) bool {
+	if isEmpty(s) || isEmpty(suffix) {
+		return false
+	}
+	return strings.HasSuffix(s, suffix)
+}

--- a/pkg/strutil/validation_test.go
+++ b/pkg/strutil/validation_test.go
@@ -351,3 +351,221 @@ func TestIsNormalizedUnicode(t *testing.T) {
 		})
 	}
 }
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		substr   string
+		expected bool
+	}{
+		{"Contains", "hello world", "hello", true},
+		{"ContainsUpper", "HELLO WORLD", "hello", false},
+		{"ContainsInvalid", "hello world!", "John", false},
+		{"ContainsEmpty", "", "hello", false},
+		{"ContainsEmptySubstr", "hello", "", false},
+		{"ContainsEmptyBoth", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := contains(tt.input, tt.substr)
+			result := Contains(tt.input, tt.substr)
+			builderResult := New(tt.input).RequireContains(tt.substr).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("Contains(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.substr, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContainsIgnoreCase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		substr   string
+		expected bool
+	}{
+		{"Contains", "hello world", "HELLO", true},
+		{"ContainsUpper", "HELLO WORLD", "hello", true},
+		{"ContainsInvalid", "hello world!", "John", false},
+		{"ContainsEmpty", "", "hello", false},
+		{"ContainsEmptySubstr", "hello", "", false},
+		{"ContainsEmptyBoth", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := containsIgnoreCase(tt.input, tt.substr)
+			result := ContainsIgnoreCase(tt.input, tt.substr)
+			builderResult := New(tt.input).RequireContainsIgnoreCase(tt.substr).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("ContainsIgnoreCase(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.substr, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		substrs  []string
+		expected bool
+	}{
+		{"Contains", "hello world", []string{"hello", "world"}, true},
+		{"ContainsUpper", "HELLO WORLD", []string{"hello", "world"}, false},
+		{"ContainsInvalid", "hello world!", []string{"hi", "John"}, false},
+		{"ContainsOneInvalid", "hello world!", []string{"hello", "John"}, true},
+		{"ContainsEmpty", "", []string{"hello", "world"}, false},
+		{"ContainsEmptySubstr", "hello", []string{}, false},
+		{"ContainsEmptyBoth", "", []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := containsAny(tt.input, tt.substrs)
+			result := ContainsAny(tt.input, tt.substrs)
+			builderResult := New(tt.input).RequireContainsAny(tt.substrs).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("ContainsAny(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.substrs, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContainsAnyIgnoreCase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		substrs  []string
+		expected bool
+	}{
+		{"Contains", "hello world", []string{"HELLO", "WORLD"}, true},
+		{"ContainsUpper", "HELLO WORLD", []string{"hello", "world"}, true},
+		{"ContainsInvalid", "hello world!", []string{"hi", "John"}, false},
+		{"ContainsOneInvalid", "hello world!", []string{"hello", "John"}, true},
+		{"ContainsEmpty", "", []string{"hello", "world"}, false},
+		{"ContainsEmptySubstr", "hello", []string{}, false},
+		{"ContainsEmptyBoth", "", []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := containsAnyIgnoreCase(tt.input, tt.substrs)
+			result := ContainsAnyIgnoreCase(tt.input, tt.substrs)
+			builderResult := New(tt.input).RequireContainsAnyIgnoreCase(tt.substrs).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("ContainsAnyIgnoreCase(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.substrs, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContainsAll(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		substrs  []string
+		expected bool
+	}{
+		{"Contains", "hello world", []string{"hello", "world"}, true},
+		{"ContainsUpper", "HELLO WORLD", []string{"hello", "world"}, false},
+		{"ContainsInvalid", "hello world!", []string{"hi", "John"}, false},
+		{"ContainsOneInvalid", "hello world!", []string{"hello", "John"}, false},
+		{"ContainsEmpty", "", []string{"hello", "world"}, false},
+		{"ContainsEmptySubstr", "hello", []string{}, false},
+		{"ContainsEmptyBoth", "", []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := containsAll(tt.input, tt.substrs)
+			result := ContainsAll(tt.input, tt.substrs)
+			builderResult := New(tt.input).RequireContainsAll(tt.substrs).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("ContainsAll(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.substrs, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContainsAllIgnoreCase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		substrs  []string
+		expected bool
+	}{
+		{"Contains", "hello world", []string{"hello", "WORLD"}, true},
+		{"ContainsUpper", "HELLO WORLD", []string{"hello", "world"}, true},
+		{"ContainsInvalid", "hello world!", []string{"hi", "John"}, false},
+		{"ContainsOneInvalid", "hello world!", []string{"hello", "John"}, false},
+		{"ContainsEmpty", "", []string{"hello", "world"}, false},
+		{"ContainsEmptySubstr", "hello", []string{}, false},
+		{"ContainsEmptyBoth", "", []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := containsAllIgnoreCase(tt.input, tt.substrs)
+			result := ContainsAllIgnoreCase(tt.input, tt.substrs)
+			builderResult := New(tt.input).RequireContainsAllIgnoreCase(tt.substrs).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("ContainsAllIgnoreCase(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.substrs, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		prefix   string
+		expected bool
+	}{
+		{"HasPrefix", "Prehistoric", "Pre", true},
+		{"HasPrefixUpper", "APP_ENV_VAR", "APP", true},
+		{"HasPrefixInvalid", "hello world!", "hi", false},
+		{"HasPrefixEmpty", "", "hello", false},
+		{"HasPrefixEmptyPrefix", "hello", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := hasPrefix(tt.input, tt.prefix)
+			result := HasPrefix(tt.input, tt.prefix)
+			builderResult := New(tt.input).RequireHasPrefix(tt.prefix).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("HasPrefix(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.prefix, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHasSuffix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		suffix   string
+		expected bool
+	}{
+		{"HasPrefix", "Running", "ing", true},
+		{"HasPrefixUpper", "APP_ENV_VAR_DEV", "DEV", true},
+		{"HasPrefixInvalid", "hello world!", "hi", false},
+		{"HasPrefixEmpty", "", "hello", false},
+		{"HasPrefixEmptyPrefix", "hello", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			helperResult := hasSuffix(tt.input, tt.suffix)
+			result := HasSuffix(tt.input, tt.suffix)
+			builderResult := New(tt.input).RequireHasSuffix(tt.suffix).Error() == nil
+			if result != tt.expected || helperResult != tt.expected || builderResult != tt.expected {
+				t.Errorf("HasPrefix(%q, %q) = %t/%t/%t; want %t",
+					tt.input, tt.suffix, helperResult, result, builderResult, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary
This pull request includes:
- Addition of missing tests for `Require*` methods.
- Updated validation logic for improved error handling.
- Implementation of validation helper methods for string operations:
  - `Contains`, `ContainsIgnoreCase`.
  - `ContainsAny`, `ContainsAnyIgnoreCase`.
  - `ContainsAll`, `ContainsAllIgnoreCase`.
  - `HasPrefix`, `HasSuffix`.
- Corresponding tests for the newly added helper methods.